### PR TITLE
Unit tests to cover GildedRose class

### DIFF
--- a/ruby/gilded_rose.rb
+++ b/ruby/gilded_rose.rb
@@ -1,4 +1,5 @@
 class GildedRose
+  MAX_QUALITY = 50
 
   def initialize(items)
     @items = items

--- a/ruby/gilded_rose_tests.rb
+++ b/ruby/gilded_rose_tests.rb
@@ -2,14 +2,12 @@ require File.join(File.dirname(__FILE__), 'gilded_rose')
 require 'test/unit'
 
 class TestUntitled < Test::Unit::TestCase
-  MAX_QUALITY = 50
-
   test "Once the sell by date has passed, quality degrades twice as fast" do
     initial_expired_item_quality = 2
     initial_unexpired_item_quality = 2
 
-    expired_item = Item.new(name = "TestItem", sell_in = 0, quality = initial_expired_item_quality)
-    unexpired_item = Item.new(name = "TestItem", sell_in = 2, quality = initial_unexpired_item_quality)
+    expired_item = create_item(name: "TestItem", sell_in: 0, quality: initial_expired_item_quality)
+    unexpired_item = create_item(name: "TestItem", sell_in: 2, quality: initial_unexpired_item_quality)
 
     items = [expired_item, unexpired_item]
     GildedRose.new(items).update_quality
@@ -19,7 +17,7 @@ class TestUntitled < Test::Unit::TestCase
   end
 
   test "Once the sell by date has passed, quality degrades but it does not drop below zero" do
-    expired_item = Item.new(name = "TestItem", sell_in = 0, quality = 0)
+    expired_item = create_item(name: "TestItem", sell_in: 0, quality: 0)
 
     gilded_rose = GildedRose.new([expired_item])
 
@@ -31,7 +29,7 @@ class TestUntitled < Test::Unit::TestCase
     number_of_updates = 10
     initial_item_sell_in = 4
 
-    item = Item.new(name = "TestItem", sell_in = initial_item_sell_in, quality = 0)
+    item = create_item(name: "TestItem", sell_in: initial_item_sell_in, quality: 0)
     gilded_rose = GildedRose.new([item])
     number_of_updates.times { gilded_rose.update_quality }
 
@@ -44,7 +42,7 @@ class TestUntitled < Test::Unit::TestCase
     initial_item_sell_in = 10
     initial_item_quality = 0
 
-    item = Item.new(name = "Aged Brie", sell_in = initial_item_sell_in, quality = initial_item_quality)
+    item = create_item(name: "Aged Brie", sell_in: initial_item_sell_in, quality: initial_item_quality)
 
     gilded_rose = GildedRose.new([item])
     number_of_updates.times { gilded_rose.update_quality }
@@ -57,19 +55,18 @@ class TestUntitled < Test::Unit::TestCase
     initial_item_sell_in = 10
     initial_item_quality = 0
 
-    item = Item.new(name = "Aged Brie", sell_in = initial_item_sell_in, quality = initial_item_quality)
+    item = create_item(name: "Aged Brie", sell_in: initial_item_sell_in, quality: initial_item_quality)
 
     gilded_rose = GildedRose.new([item])
-    (MAX_QUALITY + 1).times { gilded_rose.update_quality }
+    (GildedRose::MAX_QUALITY + 1).times { gilded_rose.update_quality }
 
-    assert_equal MAX_QUALITY, item.quality
+    assert_equal GildedRose::MAX_QUALITY, item.quality
   end
 
-  test "Sulfuras sell by date does not decrease after every update_quality" do
-    number_of_updates = 20
+  test "Sulfuras sell-by-date never decrease" do
     initial_item_sell_in = 10
 
-    item = Item.new(name = "Sulfuras, Hand of Ragnaros", sell_in = initial_item_sell_in, quality = 10)
+    item = create_item(name: "Sulfuras, Hand of Ragnaros", sell_in: initial_item_sell_in, quality: 10)
 
     gilded_rose = GildedRose.new([item])
     gilded_rose.update_quality
@@ -77,10 +74,10 @@ class TestUntitled < Test::Unit::TestCase
     assert_equal initial_item_sell_in, item.sell_in
   end
 
-  test "Sulfuras quality does not decrease after each update_quality" do
+  test "Sulfuras quality never decrease" do
     initial_item_quality = 10
 
-    item = Item.new(name = "Sulfuras, Hand of Ragnaros", sell_in = 10, quality = initial_item_quality)
+    item = create_item(name: "Sulfuras, Hand of Ragnaros", sell_in: 10, quality: initial_item_quality)
 
     gilded_rose = GildedRose.new([item])
     gilded_rose.update_quality
@@ -88,38 +85,49 @@ class TestUntitled < Test::Unit::TestCase
     assert_equal initial_item_quality, item.quality
   end
 
-  test "Backstage passes quality increases by 2 when the item has 10 days or less to expire" do
-    initial_item_quality = 10
+  (5..10).each do |day| do
+    test "Backstage passes quality increases by 2 when the item has #{day} days or less to expire" do
+      initial_item_quality = 10
 
-    item = Item.new(name = "Backstage passes to a TAFKAL80ETC concert", sell_in = 10, quality = initial_item_quality)
+      item = create_item(name: "Backstage passes to a TAFKAL80ETC concert", sell_in: 10, quality: initial_item_quality)
 
-    gilded_rose = GildedRose.new([item])
-    gilded_rose.update_quality
+      gilded_rose = GildedRose.new([item])
+      gilded_rose.update_quality
 
-    expected_item_quality = initial_item_quality + 2
-    assert_equal expected_item_quality, item.quality
+      expected_item_quality = initial_item_quality + 2
+      assert_equal expected_item_quality, item.quality
+    end
   end
 
-  test "Backstage passes quality increases by 3 when the item has 5 days or less to expire" do
-    initial_item_quality = 10
+  (1..5).each do |day|
+    test "Backstage passes quality increases by 3 when the item has #{day} days or less to expire" do
+      initial_item_quality = 10
 
-    item = Item.new(name = "Backstage passes to a TAFKAL80ETC concert", sell_in = 5, quality = initial_item_quality)
+      item = create_item(name: "Backstage passes to a TAFKAL80ETC concert", sell_in: day, quality: initial_item_quality)
 
-    gilded_rose = GildedRose.new([item])
-    gilded_rose.update_quality
+      gilded_rose = GildedRose.new([item])
+      gilded_rose.update_quality
 
-    expected_item_quality = initial_item_quality + 3
-    assert_equal expected_item_quality, item.quality
+      expected_item_quality = initial_item_quality + 3
+      assert_equal expected_item_quality, item.quality
+    end
   end
 
   test "Backstage passes quality drops to 0 when the item is expired" do
     initial_expired_item_quality = 10
     initial_expired_item_sell_in = 0
-    item = Item.new(name = "Backstage passes to a TAFKAL80ETC concert", sell_in = initial_expired_item_sell_in, quality = initial_expired_item_quality)
+    item = create_item(name: "Backstage passes to a TAFKAL80ETC concert", sell_in: initial_expired_item_sell_in, quality: initial_expired_item_quality)
 
     gilded_rose = GildedRose.new([item])
     gilded_rose.update_quality
 
     assert_equal 0, item.quality
+  end
+
+
+  private
+
+  def create_item(name:, sell_in:, quality:)
+    Item.new(name, sell_in, quality)
   end
 end

--- a/ruby/gilded_rose_tests.rb
+++ b/ruby/gilded_rose_tests.rb
@@ -2,11 +2,124 @@ require File.join(File.dirname(__FILE__), 'gilded_rose')
 require 'test/unit'
 
 class TestUntitled < Test::Unit::TestCase
+  MAX_QUALITY = 50
 
-  def test_foo
-    items = [Item.new("foo", 0, 0)]
-    GildedRose.new(items).update_quality()
-    assert_equal items[0].name, "fixme"
+  test "Once the sell by date has passed, quality degrades twice as fast" do
+    initial_expired_item_quality = 2
+    initial_unexpired_item_quality = 2
+
+    expired_item = Item.new(name = "TestItem", sell_in = 0, quality = initial_expired_item_quality)
+    unexpired_item = Item.new(name = "TestItem", sell_in = 2, quality = initial_unexpired_item_quality)
+
+    items = [expired_item, unexpired_item]
+    GildedRose.new(items).update_quality
+
+    assert_equal initial_expired_item_quality - 2, expired_item.quality
+    assert_equal initial_unexpired_item_quality - 1, unexpired_item.quality
   end
 
+  test "Once the sell by date has passed, quality degrades but it does not drop below zero" do
+    expired_item = Item.new(name = "TestItem", sell_in = 0, quality = 0)
+
+    gilded_rose = GildedRose.new([expired_item])
+
+    gilded_rose.update_quality
+    assert_equal 0, expired_item.quality
+  end
+
+  test "After every update_quality call, sell_in is reduced by 1" do
+    number_of_updates = 10
+    initial_item_sell_in = 4
+
+    item = Item.new(name = "TestItem", sell_in = initial_item_sell_in, quality = 0)
+    gilded_rose = GildedRose.new([item])
+    number_of_updates.times { gilded_rose.update_quality }
+
+    expected_item_sell_in = initial_item_sell_in - number_of_updates
+    assert_equal expected_item_sell_in, item.sell_in
+  end
+
+  test "Aged Brie item increases in Quality the older it gets" do
+    number_of_updates = 10
+    initial_item_sell_in = 10
+    initial_item_quality = 0
+
+    item = Item.new(name = "Aged Brie", sell_in = initial_item_sell_in, quality = initial_item_quality)
+
+    gilded_rose = GildedRose.new([item])
+    number_of_updates.times { gilded_rose.update_quality }
+
+    expected_item_quality = initial_item_quality + number_of_updates
+    assert_equal expected_item_quality, item.quality
+  end
+
+  test "Aged Brie item increases in Quality the older it gets, but it does not exceed 50 in quality" do
+    initial_item_sell_in = 10
+    initial_item_quality = 0
+
+    item = Item.new(name = "Aged Brie", sell_in = initial_item_sell_in, quality = initial_item_quality)
+
+    gilded_rose = GildedRose.new([item])
+    (MAX_QUALITY + 1).times { gilded_rose.update_quality }
+
+    assert_equal MAX_QUALITY, item.quality
+  end
+
+  test "Sulfuras sell by date does not decrease after every update_quality" do
+    number_of_updates = 20
+    initial_item_sell_in = 10
+
+    item = Item.new(name = "Sulfuras, Hand of Ragnaros", sell_in = initial_item_sell_in, quality = 10)
+
+    gilded_rose = GildedRose.new([item])
+    gilded_rose.update_quality
+
+    assert_equal initial_item_sell_in, item.sell_in
+  end
+
+  test "Sulfuras quality does not decrease after each update_quality" do
+    initial_item_quality = 10
+
+    item = Item.new(name = "Sulfuras, Hand of Ragnaros", sell_in = 10, quality = initial_item_quality)
+
+    gilded_rose = GildedRose.new([item])
+    gilded_rose.update_quality
+
+    assert_equal initial_item_quality, item.quality
+  end
+
+  test "Backstage passes quality increases by 2 when the item has 10 days or less to expire" do
+    initial_item_quality = 10
+
+    item = Item.new(name = "Backstage passes to a TAFKAL80ETC concert", sell_in = 10, quality = initial_item_quality)
+
+    gilded_rose = GildedRose.new([item])
+    gilded_rose.update_quality
+
+    expected_item_quality = initial_item_quality + 2
+    assert_equal expected_item_quality, item.quality
+  end
+
+  test "Backstage passes quality increases by 3 when the item has 5 days or less to expire" do
+    initial_item_quality = 10
+
+    item = Item.new(name = "Backstage passes to a TAFKAL80ETC concert", sell_in = 5, quality = initial_item_quality)
+
+    gilded_rose = GildedRose.new([item])
+    gilded_rose.update_quality
+
+    expected_item_quality = initial_item_quality + 3
+    assert_equal expected_item_quality, item.quality
+  end
+
+  test "Backstage passes quality drops to 0 when the item is expired" do
+    initial_expired_item_quality = 10
+    initial_expired_item_sell_in = 0
+    item = Item.new(name = "Backstage passes to a TAFKAL80ETC concert", sell_in = initial_expired_item_sell_in, quality = initial_expired_item_quality)
+
+    gilded_rose = GildedRose.new([item])
+    gilded_rose.update_quality
+
+    assert_equal 0, item.quality
+  end
 end


### PR DESCRIPTION
In this PR, we added unit test to cover GildedRose for the following scenarios: 

- Once the sell by date has passed, Quality degrades twice as fast
- The Quality of an item is never negative
- "Aged Brie" actually increases in Quality the older it gets
- The Quality of an item is never more than 50
- "Sulfuras", being a legendary item, never has to be sold or decreases in Quality
- "Backstage passes", like aged brie, increases in Quality as its SellIn value approaches;
 Quality increases by 2 when there are 10 days or less and by 3 when there are 5 days or less but
 Quality drops to 0 after the concert
```